### PR TITLE
Fix: Correct syntax error in JavaScript

### DIFF
--- a/script.js
+++ b/script.js
@@ -81,7 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
             answers: [
                 { text: 'Marubozu Alcista', correct: true },
                 { text: 'Doji', correct: false },
-.                { text: 'Marubozu Bajista', correct: false },
+                { text: 'Marubozu Bajista', correct: false },
             ],
         },
         {


### PR DESCRIPTION
This commit fixes a bug that prevented the application's content from loading. A stray dot in the `quizQuestions` array in `script.js` caused a JavaScript syntax error, which stopped the script from executing and rendering the dynamic content.

The fix removes the typo, allowing the application to load and function as intended.