### PR TITLE
Fix: Correct image visibility and size issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Aprende Velas Japonesas</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Guía para Inversores: Cómo Leer Velas Japonesas</h1>
+    </header>
+
+    <main id="app">
+        <!-- El contenido de la aplicación se generará aquí -->
+    </main>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,183 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const app = document.getElementById('app');
+
+    // --- Data ---
+    const introduction = `
+        <section>
+            <h2>¿Qué es una Vela Japonesa?</h2>
+            <p>Las velas japonesas son una forma de gráfico financiero que se utiliza para describir los movimientos de precios de un activo. Cada vela representa un período de tiempo (por ejemplo, un día, una hora) y muestra cuatro datos clave:</p>
+            <ul>
+                <li><strong>Apertura (Open):</strong> El precio al inicio del período.</li>
+                <li><strong>Cierre (Close):</strong> El precio al final del período.</li>
+                <li><strong>Máximo (High):</strong> El precio más alto alcanzado durante el período.</li>
+                <li><strong>Mínimo (Low):</strong> El precio más bajo alcanzado durante el período.</li>
+            </ul>
+            <p>El "cuerpo" de la vela es la parte ancha entre el precio de apertura y el de cierre. Las "mechas" o "sombras" son las líneas delgadas que se extienden desde el cuerpo hasta los precios máximo y mínimo.</p>
+            <p><strong>Vela Alcista (Bullish):</strong> Generalmente de color verde o blanco, se forma cuando el precio de cierre es más alto que el de apertura. Indica presión de compra.</p>
+            <p><strong>Vela Bajista (Bearish):</strong> Generalmente de color rojo o negro, se forma cuando el precio de cierre es más bajo que el de apertura. Indica presión de venta.</p>
+        </section>
+    `;
+
+    const patterns = [
+        {
+            title: 'Doji',
+            image: 'https://upload.wikimedia.org/wikipedia/commons/7/78/Candlestick_pattern_Doji_Star.svg',
+            description: 'Un Doji se forma cuando la apertura y el cierre son prácticamente iguales. Indica indecisión en el mercado. Por sí solo es neutral, pero puede señalar una posible reversión dependiendo del contexto.',
+        },
+        {
+            title: 'Marubozu',
+            image: 'https://upload.wikimedia.org/wikipedia/commons/0/07/Candle_marubozu_black.svg',
+            description: 'Un Marubozu es una vela sin mechas (o sombras). Un Marubozu alcista (verde) abre en su mínimo y cierra en su máximo, indicando una fuerte presión de compra. Un Marubozu bajista (rojo) abre en su máximo y cierra en su mínimo, mostrando una fuerte presión de venta.',
+        },
+        {
+            title: 'Martillo (Hammer)',
+            image: 'https://upload.wikimedia.org/wikipedia/commons/1/15/Candle_hammer.svg',
+            description: 'Aparece en una tendencia bajista. Tiene un cuerpo pequeño en la parte superior y una mecha inferior larga. Sugiere una posible reversión alcista, ya que los compradores empujaron los precios hacia arriba.',
+        },
+        {
+            title: 'Envolvente Alcista (Bullish Engulfing)',
+            image: 'https://upload.wikimedia.org/wikipedia/commons/2/23/Candlestick_pattern_bullish_engulfing.svg',
+            description: 'Es un patrón de dos velas. Una pequeña vela bajista es seguida por una gran vela alcista que "envuelve" completamente a la anterior. Es una fuerte señal de reversión alcista.',
+        },
+        {
+            title: 'Envolvente Bajista (Bearish Engulfing)',
+            image: 'https://upload.wikimedia.org/wikipedia/commons/0/0c/Candlestick_pattern_bearish_engulfing.svg',
+            description: 'Lo contrario al envolvente alcista. Ocurre en una tendencia alcista, donde una pequeña vela alcista es seguida por una gran vela bajista que la envuelve. Es una señal de reversión bajista.',
+        },
+        {
+            title: 'Estrella del Amanecer (Morning Star)',
+            image: 'https://upload.wikimedia.org/wikipedia/commons/e/e3/Candlestick_pattern_bullish_Morning_Doji_Star.svg',
+            description: 'Patrón de tres velas que indica una reversión alcista. Comienza con una vela bajista, seguida de una pequeña vela de indecisión (como un Doji) y finaliza con una vela alcista que cierra por encima del punto medio de la primera vela.',
+        },
+        {
+            title: 'Estrella del Anochecer (Evening Star)',
+            image: 'https://upload.wikimedia.org/wikipedia/commons/c/c4/Candlestick_pattern_bearish_Evening_Doji_Star.svg',
+            description: 'Es un patrón de tres velas que señala una reversión bajista. Comienza con una gran vela alcista, seguida de una pequeña vela y termina con una vela bajista que cierra por debajo del punto medio de la primera vela.',
+        }
+    ];
+
+    const quizQuestions = [
+        {
+            question: '¿Qué patrón de vela indica indecisión en el mercado, con precios de apertura y cierre casi idénticos?',
+            image: 'https://upload.wikimedia.org/wikipedia/commons/7/78/Candlestick_pattern_Doji_Star.svg',
+            answers: [
+                { text: 'Martillo', correct: false },
+                { text: 'Doji', correct: true },
+                { text: 'Marubozu', correct: false },
+            ],
+        },
+        {
+            question: 'En una tendencia bajista, aparece una vela con un cuerpo pequeño y una mecha inferior larga. ¿Qué patrón es y qué sugiere?',
+            image: 'https://upload.wikimedia.org/wikipedia/commons/1/15/Candle_hammer.svg',
+            answers: [
+                { text: 'Estrella del Anochecer, reversión bajista', correct: false },
+                { text: 'Martillo, reversión alcista', correct: true },
+                { text: 'Envolvente Bajista, reversión bajista', correct: false },
+            ],
+        },
+        {
+            question: 'Una vela sin mechas que cierra por encima de su apertura, mostrando un fuerte dominio comprador. ¿Cómo se llama?',
+            image: 'https://upload.wikimedia.org/wikipedia/commons/0/07/Candle_marubozu_black.svg',
+            answers: [
+                { text: 'Marubozu Alcista', correct: true },
+                { text: 'Doji', correct: false },
+                { text: 'Marubozu Bajista', correct: false },
+            ],
+        },
+        {
+            question: 'Después de una tendencia alcista, una pequeña vela alcista es completamente "envuelta" por una gran vela bajista. ¿Qué señal nos da?',
+            image: 'https://upload.wikimedia.org/wikipedia/commons/0/0c/Candlestick_pattern_bearish_engulfing.svg',
+            answers: [
+                { text: 'Continuación de la tendencia alcista', correct: false },
+                { text: 'Reversión bajista (Envolvente Bajista)', correct: true },
+                { text: 'Indecisión del mercado', correct: false },
+            ],
+        }
+    ];
+
+    // --- Render Functions ---
+    function renderContent() {
+        let patternsHtml = patterns.map(p => {
+            const isSolid = p.title === 'Marubozu' || p.title === 'Martillo (Hammer)';
+            const imageClass = isSolid ? 'pattern-image solid-svg' : 'pattern-image';
+            return `
+                <article class="pattern-card">
+                    <h3>${p.title}</h3>
+                    <img src="${p.image}" alt="${p.title}" class="${imageClass}">
+                    <p>${p.description}</p>
+                </article>
+            `;
+        }).join('');
+
+        app.innerHTML = `
+            ${introduction}
+            <section>
+                <h2>Patrones de Velas Comunes</h2>
+                <div class="patterns-container">
+                    ${patternsHtml}
+                </div>
+            </section>
+            <section id="quiz">
+                <h2>Pon a Prueba tu Conocimiento</h2>
+                <div id="quiz-container"></div>
+            </section>
+        `;
+
+        renderQuiz();
+    }
+
+    function renderQuiz() {
+        const quizContainer = document.getElementById('quiz-container');
+        quizContainer.innerHTML = '';
+        quizQuestions.forEach((q, index) => {
+            const answersHtml = q.answers.map(a =>
+                `<button data-correct="${a.correct}">${a.text}</button>`
+            ).join('');
+
+            const isSolid = q.image.includes('marubozu') || q.image.includes('hammer');
+            const imageClass = isSolid ? 'pattern-image solid-svg' : 'pattern-image';
+            quizContainer.innerHTML += `
+                <div class="quiz-question" id="question-${index}">
+                    <p>${index + 1}. ${q.question}</p>
+                    <img src="${q.image}" alt="Quiz Image ${index + 1}" class="${imageClass}">
+                    <div class="answers">${answersHtml}</div>
+                    <div class="feedback"></div>
+                </div>
+            `;
+        });
+
+        addQuizListeners();
+    }
+
+    function addQuizListeners() {
+        const quiz = document.getElementById('quiz');
+        quiz.addEventListener('click', (e) => {
+            if (e.target.tagName === 'BUTTON') {
+                const button = e.target;
+                const questionDiv = button.closest('.quiz-question');
+                const feedbackEl = questionDiv.querySelector('.feedback');
+                const isCorrect = button.dataset.correct === 'true';
+
+                // Reset sibling buttons style
+                const answerButtons = questionDiv.querySelectorAll('.answers button');
+                answerButtons.forEach(btn => btn.classList.remove('correct', 'incorrect'));
+
+                if (isCorrect) {
+                    button.classList.add('correct');
+                    feedbackEl.textContent = '¡Correcto! Buen trabajo.';
+                    feedbackEl.className = 'feedback correct';
+                } else {
+                    button.classList.add('incorrect');
+                    feedbackEl.textContent = 'Incorrecto. La respuesta correcta está marcada en verde.';
+                    feedbackEl.className = 'feedback incorrect';
+                    // Highlight the correct answer
+                    const correctButton = questionDiv.querySelector('button[data-correct="true"]');
+                    correctButton.classList.add('correct');
+                }
+            }
+        });
+    }
+
+    // --- Initial Load ---
+    renderContent();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,231 @@
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap');
+
+:root {
+    --bg-dark: #1a1a1d;
+    --bg-light: #2c2c34;
+    --text-primary: #f0f0f0;
+    --text-secondary: #a9a9b3;
+    --accent-gold: #c9a227;
+    --bullish-green: #26a69a;
+    --bearish-red: #ef5350;
+    --border-color: #404048;
+}
+
+body {
+    font-family: 'Lato', sans-serif;
+    line-height: 1.7;
+    margin: 0;
+    padding: 0;
+    background: var(--bg-dark);
+    color: var(--text-primary);
+}
+
+header {
+    background: var(--bg-light);
+    color: #fff;
+    padding: 1.5rem 1rem;
+    text-align: center;
+    border-bottom: 3px solid var(--accent-gold);
+}
+
+h1 {
+    margin: 0;
+    font-size: 2.2rem;
+    color: var(--accent-gold);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+main {
+    padding: 2rem 1rem;
+    max-width: 960px;
+    margin: auto;
+}
+
+section {
+    background: var(--bg-light);
+    padding: 2rem;
+    margin-bottom: 2rem;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+}
+
+h2 {
+    color: var(--accent-gold);
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 10px;
+    margin-top: 0;
+    font-size: 1.8rem;
+}
+
+article {
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+article:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+}
+
+article h3 {
+    color: var(--text-primary);
+    font-size: 1.4rem;
+}
+
+p, li {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+}
+
+strong {
+    color: var(--text-primary);
+}
+
+.pattern-image {
+    max-width: 120px;
+    display: block;
+    margin: 1.5rem auto;
+    filter: invert(1) hue-rotate(180deg); /* Adjust SVG colors for dark theme */
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    padding: 10px;
+    background-color: #fff;
+}
+
+.pattern-image.solid-svg {
+    background-color: transparent;
+}
+
+#quiz button {
+    display: block;
+    width: 100%;
+    padding: 15px;
+    margin-top: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    background-color: var(--bg-dark);
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    font-size: 1.1rem;
+    text-align: left;
+}
+
+#quiz button:hover {
+    background-color: var(--accent-gold);
+    color: var(--bg-dark);
+    border-color: var(--accent-gold);
+}
+
+#quiz button.correct {
+    background-color: var(--bullish-green);
+    border-color: var(--bullish-green);
+    color: #fff;
+    font-weight: bold;
+}
+
+#quiz button.incorrect {
+    background-color: var(--bearish-red);
+    border-color: var(--bearish-red);
+    color: #fff;
+}
+
+.quiz-question {
+    margin-bottom: 2.5rem;
+    padding: 1.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background-color: var(--bg-dark);
+}
+
+.feedback {
+    margin-top: 1.5rem;
+    padding: 1rem;
+    border-radius: 5px;
+    font-weight: bold;
+    text-align: center;
+}
+
+.feedback.correct {
+    background-color: var(--bullish-green);
+    color: #fff;
+}
+
+.feedback.incorrect {
+    background-color: var(--bearish-red);
+    color: #fff;
+}
+
+/* Card Layout for Patterns */
+.patterns-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    justify-content: center;
+}
+
+.pattern-card {
+    background: var(--bg-dark);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1.5rem;
+    flex: 1 1 300px; /* Flex properties for responsive cards */
+    max-width: 350px;
+    text-align: center;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pattern-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 15px rgba(0,0,0,0.2);
+}
+
+.pattern-card h3 {
+    color: var(--accent-gold);
+    margin-top: 0;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    h1 {
+        font-size: 1.8rem;
+    }
+
+    h2 {
+        font-size: 1.5rem;
+    }
+
+    section, .pattern-card, .quiz-question {
+        padding: 1.5rem;
+    }
+}
+
+@media (max-width: 480px) {
+    body {
+        line-height: 1.6;
+    }
+
+    main {
+        padding: 1rem 0.5rem;
+    }
+
+    h1 {
+        font-size: 1.5rem;
+        letter-spacing: 1px;
+    }
+
+    section {
+        padding: 1rem;
+    }
+
+    .pattern-card {
+        flex-basis: 100%; /* Each card takes full width */
+    }
+
+    #quiz button {
+        padding: 12px;
+        font-size: 1rem;
+    }
+}


### PR DESCRIPTION
This commit addresses two issues based on user feedback:
1.  **Invisible Images:** Some SVG images with solid bodies (Marubozu, Hammer) were rendered invisible by the dark theme's CSS filter. This has been fixed by adding a specific class (`solid-svg`) to these images and using a targeted CSS rule to remove the white background, making them visible against the dark card background. All image URLs have also been verified and corrected.
2.  **Image Size:** The candlestick images were too large, making the page unnecessarily long. The `max-width` of the images has been reduced from 150px to 120px in the CSS to make the layout more compact.